### PR TITLE
Add flag to fail in case missing artifact in external repositories

### DIFF
--- a/private/synchronizer/cli/src/main/scala/com/wix/build/sync/cli/ManagedDepsSynchronizerCli.scala
+++ b/private/synchronizer/cli/src/main/scala/com/wix/build/sync/cli/ManagedDepsSynchronizerCli.scala
@@ -57,7 +57,8 @@ abstract class SynchronizerCli {
       config.destinationPackage,
       storage,
       managedDeps,
-      config.importExternalLoadStatement
+      config.importExternalLoadStatement,
+      config.failOnMissingArtifacts
     )
   }
 

--- a/private/synchronizer/cli/src/main/scala/com/wix/build/sync/cli/ManagedDepsSynchronizerConfig.scala
+++ b/private/synchronizer/cli/src/main/scala/com/wix/build/sync/cli/ManagedDepsSynchronizerConfig.scala
@@ -15,7 +15,8 @@ case class ManagedDepsSynchronizerConfig(pathToArtifactsFile: String,
                                          pollingMaxAttempts: Int,
                                          millisBetweenPollings: Int,
                                          cacheChecksums: Boolean,
-                                         importExternalLoadStatement: ImportExternalLoadStatement) {
+                                         importExternalLoadStatement: ImportExternalLoadStatement,
+                                         failOnMissingArtifacts: Boolean) {
   val destinationPackage: DestinationPackage = DestinationPackage.resolveFromDestination(destination)
 }
 
@@ -32,6 +33,7 @@ abstract class SynchronizerConfigParser {
     millisBetweenPollings = 3000,
     cacheChecksums = true,
     importExternalLoadStatement = ImportExternalLoadStatement(null, null),
+    failOnMissingArtifacts = true,
   )
 
   private val parser = new OptionParser[ManagedDepsSynchronizerConfig](toolName) {
@@ -113,6 +115,12 @@ abstract class SynchronizerConfigParser {
         config.copy(importExternalLoadStatement = config.importExternalLoadStatement.copy(importExternalRulePath = path))
       }
 
+    opt[Boolean](name = "fail-on-missing-artifacts")
+      .optional()
+      .text("Fail with an exception, aggregating all missing artifacts, if any")
+      .action {
+        case (param, config) => config.copy(failOnMissingArtifacts = param)
+      }
 
     help("help")
   }

--- a/private/synchronizer/synchronizer/src/main/scala/com/wix/build/bazel/MissingArtifactsException.scala
+++ b/private/synchronizer/synchronizer/src/main/scala/com/wix/build/bazel/MissingArtifactsException.scala
@@ -1,0 +1,4 @@
+package com.wix.build.bazel
+
+case class MissingArtifactsException(missingArtifactsCoordinates: Set[String])
+  extends RuntimeException(s"Missing artifacts: \n${missingArtifactsCoordinates.mkString("\n")}")

--- a/private/synchronizer/synchronizer/src/main/scala/com/wix/build/sync/core/ManagedDependenciesSynchronizer.scala
+++ b/private/synchronizer/synchronizer/src/main/scala/com/wix/build/sync/core/ManagedDependenciesSynchronizer.scala
@@ -14,7 +14,8 @@ class ManagedDependenciesSynchronizer(mavenDependencyResolver: MavenDependencyRe
                                       destinationPackage: DestinationPackage,
                                       dependenciesRemoteStorage: DependenciesRemoteStorage,
                                       managedDependencies: List[Dependency],
-                                      importExternalLoadStatement: ImportExternalLoadStatement)
+                                      importExternalLoadStatement: ImportExternalLoadStatement,
+                                      failOnMissingArtifacts: Boolean)
   extends DependenciesSynchronizer {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -31,7 +32,8 @@ class ManagedDependenciesSynchronizer(mavenDependencyResolver: MavenDependencyRe
         managedDependenciesRepoPath.toFile,
         new ThirdPartyPaths(destination, destinationPackage),
       ),
-      importExternalLoadStatement = importExternalLoadStatement
+      importExternalLoadStatement = importExternalLoadStatement,
+      failOnMissingArtifacts = failOnMissingArtifacts
     ).writeDependencies(dependenciesToUpdateWithChecksums)
   }
 


### PR DESCRIPTION
Introduced new flag to change behaviour if artifact is not found in repository. Instead of printing `# fixme: missing jar` near artifacts coordinates, the command will fail with exception. Default behaviour is not changed, flag must be enabled explicitly.

--fail-on-missing-artifacts - Fail with an exception, aggregating all missing artifacts, if any