### PR TITLE
Propagate testonly attribute from maven artifacts to import_external

### DIFF
--- a/private/resolver/api/src/main/scala/com/wix/build/maven/Dependency.scala
+++ b/private/resolver/api/src/main/scala/com/wix/build/maven/Dependency.scala
@@ -3,6 +3,7 @@ package com.wix.build.maven
 case class Dependency(coordinates: Coordinates,
                       scope: MavenScope,
                       isNeverLink: Boolean = false,
+                      isTestOnly: Boolean = false,
                       exclusions: Set[Exclusion] = Set.empty,
                       aliases: Set[String] = Set.empty,
                       tags: Set[String] = Set.empty,
@@ -24,6 +25,8 @@ case class Dependency(coordinates: Coordinates,
   def withScope(scope: MavenScope): Dependency = copy(scope = scope)
 
   def withIsNeverLink(isNeverLink: Boolean): Dependency = copy(isNeverLink = isNeverLink)
+
+  def withIsTestOnly(isTestOnly: Boolean): Dependency = copy(isTestOnly = isTestOnly)
 
   def equalsOnCoordinatesIgnoringVersion(dependency: Dependency): Boolean =
     dependency.coordinates.equalsIgnoringVersion(coordinates)

--- a/private/resolver/testkit/src/main/scala/com/wix/build/maven/MavenMakers.scala
+++ b/private/resolver/testkit/src/main/scala/com/wix/build/maven/MavenMakers.scala
@@ -27,7 +27,7 @@ object MavenMakers {
                        artifactIdPrefix: String = defaultArtifactPrefix,
                        index: Int = Random.nextInt(),
                        withExclusions: Set[Exclusion] = Set.empty): Dependency =
-    Dependency(randomCoordinates(withVersion, artifactIdPrefix, index), withScope, false, withExclusions)
+    Dependency(coordinates = randomCoordinates(withVersion, artifactIdPrefix, index), scope = withScope, exclusions = withExclusions)
 
   def someCoordinates(artifactId: String, packaging: Packaging = Packaging("jar")): Coordinates =
     Coordinates("some.group", artifactId, "some-version", packaging)
@@ -38,18 +38,18 @@ object MavenMakers {
   def aDependency(artifactId: String,
                   scope: MavenScope = MavenScope.Compile,
                   exclusions: Set[Exclusion] = Set.empty): Dependency =
-    Dependency(someCoordinates(artifactId), scope, false, exclusions)
+    Dependency(coordinates = someCoordinates(artifactId), scope = scope, exclusions = exclusions)
 
   def aPomArtifactDependency(artifactId: String,
                              scope: MavenScope = MavenScope.Compile,
                              exclusions: Set[Exclusion] = Set.empty): Dependency =
-    Dependency(someCoordinates(artifactId).copy(packaging = Packaging("pom")), scope, false, exclusions)
+    Dependency(coordinates = someCoordinates(artifactId).copy(packaging = Packaging("pom")), scope = scope, exclusions = exclusions)
 
   def asCompileDependency(artifact: Coordinates, exclusions: Set[Exclusion] = Set.empty): Dependency =
-    Dependency(artifact, MavenScope.Compile, false, exclusions)
+    Dependency(coordinates = artifact, scope = MavenScope.Compile, exclusions = exclusions)
 
   def asRuntimeDependency(artifact: Coordinates, exclusions: Set[Exclusion] = Set.empty): Dependency =
-    Dependency(artifact, MavenScope.Runtime, false, exclusions)
+    Dependency(coordinates = artifact, scope = MavenScope.Runtime, exclusions = exclusions)
 
   def aTestArchiveTarDependency(artifactId: String): Dependency = Dependency(someCoordinates(artifactId)
     .copy(packaging = Packaging("tar.gz")), MavenScope.Test)

--- a/private/synchronizer/cli/src/main/scala/com/wix/build/sync/cli/RulesMavenThirdPartyDomain.scala
+++ b/private/synchronizer/cli/src/main/scala/com/wix/build/sync/cli/RulesMavenThirdPartyDomain.scala
@@ -24,6 +24,7 @@ object RulesMavenThirdPartyDomain {
     ),
     scope = MavenScope.Compile,
     isNeverLink = d.neverLink.contains(true),
+    isTestOnly = d.testonly.contains(true),
     exclusions = d.exclusions.map(_.map(e => Exclusion(e.group, e.artifact))).getOrElse(Set.empty),
     tags = d.tags.getOrElse(Set.empty),
     aliases = d.aliases.getOrElse(Set.empty),

--- a/private/synchronizer/synchronizer/src/main/scala/com/wix/build/bazel/BazelDependenciesWriter.scala
+++ b/private/synchronizer/synchronizer/src/main/scala/com/wix/build/bazel/BazelDependenciesWriter.scala
@@ -185,6 +185,7 @@ class BazelDependenciesWriter(localWorkspace: BazelLocalWorkspace,
       srcChecksum = dependencyNode.srcChecksum,
       snapshotSources = dependencyNode.snapshotSources,
       neverlink = dependencyNode.neverlink,
+      testOnly = dependencyNode.testOnly,
       remapping = if (overriddenLabels.nonEmpty) collectMappings(dependencyNode, overriddenLabels) else Map.empty
     )
 
@@ -217,7 +218,8 @@ case class AnnotatedDependencyNode(baseDependency: Dependency,
                                    checksum: Option[String] = None,
                                    srcChecksum: Option[String] = None,
                                    snapshotSources: Boolean = false,
-                                   neverlink: Boolean = false)
+                                   neverlink: Boolean = false,
+                                   testOnly: Boolean = false)
 
 
 class AnnotatedDependencyNodeTransformer(neverLinkResolver: NeverLinkResolver = new NeverLinkResolver(), thirdPartyPath: String) {
@@ -235,7 +237,8 @@ class AnnotatedDependencyNodeTransformer(neverLinkResolver: NeverLinkResolver = 
       checksum = dependencyNode.checksum,
       srcChecksum = dependencyNode.srcChecksum,
       snapshotSources = dependencyNode.snapshotSources,
-      neverlink = neverLinkResolver.isNeverLink(dependencyNode.baseDependency)
+      neverlink = neverLinkResolver.isNeverLink(dependencyNode.baseDependency),
+      testOnly = dependencyNode.baseDependency.isTestOnly
     )
   }
 

--- a/private/synchronizer/synchronizer/src/main/scala/com/wix/build/bazel/ImportExternalTargetsFilePartialDependencyNodesReader.scala
+++ b/private/synchronizer/synchronizer/src/main/scala/com/wix/build/bazel/ImportExternalTargetsFilePartialDependencyNodesReader.scala
@@ -18,7 +18,7 @@ case class ImportExternalTargetsFilePartialDependencyNodesReader(content: String
       compileDeps = extractListByAttribute(CompileTimeDepsFilter, importExternalTarget)
       runtimeDeps = extractListByAttribute(RunTimeDepsFilter, importExternalTarget)
       isNeverLink = ImportExternalTargetsFileReader.extractNeverlink(importExternalTarget)
-    } yield PartialDependencyNode(name, Dependency(coordinates.coordinates, MavenScope.Compile, isNeverLink, exclusions),
+    } yield PartialDependencyNode(name, Dependency(coordinates = coordinates.coordinates, scope = MavenScope.Compile, isNeverLink = isNeverLink, exclusions = exclusions),
       compileDeps.flatMap(d => parseTargetDependency(d, MavenScope.Compile)) ++
         runtimeDeps.flatMap(d => parseTargetDependency(d, MavenScope.Runtime))
     )

--- a/private/synchronizer/synchronizer/src/main/scala/com/wix/build/bazel/RuleResolver.scala
+++ b/private/synchronizer/synchronizer/src/main/scala/com/wix/build/bazel/RuleResolver.scala
@@ -13,6 +13,7 @@ class RuleResolver(thirdPartyDestination: String) {
             srcChecksum: Option[String] = None,
             snapshotSources: Boolean = false,
             neverlink: Boolean = false,
+            testOnly: Boolean = false,
             aliases: Set[String] = Set.empty,
             tags: Set[String] = Set.empty,
             remapping: Map[String, String] = Map.empty): RuleToPersist =
@@ -30,6 +31,7 @@ class RuleResolver(thirdPartyDestination: String) {
           srcChecksum,
           snapshotSources,
           neverlink = neverlink,
+          testOnly = testOnly,
           remapping = remapping
         ),
         ImportExternalRule.ruleLocatorFrom(artifact)

--- a/private/synchronizer/synchronizer/src/main/scala/com/wix/build/sync/core/DependencyConfigAugmenter.scala
+++ b/private/synchronizer/synchronizer/src/main/scala/com/wix/build/sync/core/DependencyConfigAugmenter.scala
@@ -25,6 +25,7 @@ object DependencyConfigAugmenter {
           .map(node => addAliases(config, node))
           .map(node => addTags(config, node))
           .map(node => addNeverlink(config, node))
+          .map(node => addTestOnly(config, node))
       }
       .map(node => new CoordKey(node.baseDependency.coordinates) -> node)
   }
@@ -38,6 +39,15 @@ object DependencyConfigAugmenter {
     if (config.isNeverLink)
       dependencyNode.copy(
         baseDependency = dependencyNode.baseDependency.withIsNeverLink(config.isNeverLink)
+      )
+    else
+      dependencyNode
+  }
+
+  private def addTestOnly(config: Dependency, dependencyNode: BazelDependencyNode): BazelDependencyNode = {
+    if (config.isTestOnly)
+      dependencyNode.copy(
+        baseDependency = dependencyNode.baseDependency.withIsTestOnly(config.isTestOnly)
       )
     else
       dependencyNode

--- a/private/synchronizer/synchronizer/src/test/scala/com/wix/build/bazel/BazelDependenciesReaderTest.scala
+++ b/private/synchronizer/synchronizer/src/test/scala/com/wix/build/bazel/BazelDependenciesReaderTest.scala
@@ -211,10 +211,10 @@ class BazelDependenciesReaderTest extends SpecificationWithJUnit {
 
     def defaultDependency(groupId: String, artifactId: String, version: String, exclusion: Set[Exclusion] = Set.empty) =
       Dependency(
-        Coordinates(groupId, artifactId, version),
-        MavenScope.Compile,
+        coordinates = Coordinates(groupId, artifactId, version),
+        scope = MavenScope.Compile,
         isNeverLink = false,
-        exclusion
+        exclusions = exclusion
       )
 
     val artifact = someCoordinates("some-dep")

--- a/private/synchronizer/synchronizer/src/test/scala/com/wix/build/bazel/RuleResolverTest.scala
+++ b/private/synchronizer/synchronizer/src/test/scala/com/wix/build/bazel/RuleResolverTest.scala
@@ -107,6 +107,17 @@ class RuleResolverTest extends SpecificationWithJUnit {
         )
       )
     }
+
+    "return import external rule with testOnly flag" in new Context {
+      ruleResolver.`for`(artifact, runtimeDependencies, compileDependencies, checksum = someChecksum, testOnly = true) must containImportExternalRule(importExternalRule(
+        name = artifact.workspaceRuleName,
+        anArtifact = be_===(artifact.serialized),
+        runtimeDeps = contain(allOf(runtimeDependencies.map(_.toLabel))),
+        compileDeps = contain(allOf(compileDependencies.map(_.toLabel))),
+        checksum = be_===(someChecksum),
+        testOnly = beTrue
+      ))
+    }
   }
 
   trait Context extends Scope with Mockito with MustThrownExpectations {

--- a/private/synchronizer/synchronizer/src/test/scala/com/wix/build/sync/core/DependencyConfigAugmenterTest.scala
+++ b/private/synchronizer/synchronizer/src/test/scala/com/wix/build/sync/core/DependencyConfigAugmenterTest.scala
@@ -48,17 +48,30 @@ class DependencyConfigAugmenterTest extends SpecWithJUnit {
     DependencyConfigAugmenter.augment(deps, dependenciesConfig) mustEqual Set(node1WithTags, node2)
   }
 
+  "add testOnly" in {
+    val node1 = BazelDependencyNode(baseDependency = aDep("dep1"), Set())
+    val node2 = BazelDependencyNode(baseDependency = aDep("dep2"), Set())
+    val node1WithTestOnly = BazelDependencyNode(baseDependency = aDep("dep1", isTestOnly = true), Set())
+    val deps = Set(node1, node2)
+
+    val dependenciesConfig = List(aDep(artifactId = "dep1", isTestOnly = true))
+
+    DependencyConfigAugmenter.augment(deps, dependenciesConfig) mustEqual Set(node1WithTestOnly, node2)
+  }
+
   def aDep(artifactId: String,
            groupId: String = "group",
            version: String = "version",
            scope: MavenScope = MavenScope.Compile,
            aliases: Set[String] = Set.empty,
            tags: Set[String] = Set.empty,
-           flattenTransitiveDeps: Boolean = false): Dependency = Dependency(
+           flattenTransitiveDeps: Boolean = false,
+           isTestOnly: Boolean = false): Dependency = Dependency(
     coordinates = Coordinates(groupId = groupId, artifactId = artifactId, version = version),
     scope = scope,
     aliases = aliases,
     tags = tags,
-    flattenTransitiveDeps = flattenTransitiveDeps
+    flattenTransitiveDeps = flattenTransitiveDeps,
+    isTestOnly = isTestOnly
   )
 }


### PR DESCRIPTION
## What?

Propagates the `testonly` attribute from `wix.artifact()` definitions through the dependency resolution pipeline to the generated `import_external` rules.

## Why?

Security periodically scans docker images for vulnerabilities. Test libraries don't get the same upgrade priority and tend to have more security issues. By marking test libraries as `testonly`, we prevent them from being included in production code.

## How?

- Added `isTestOnly` field to `Dependency` case class
- Parse `testonly` from JSON in `RulesMavenThirdPartyDomain`
- Added `addTestOnly` function to `DependencyConfigAugmenter`
- Pass `testOnly` through `AnnotatedDependencyNode` and `RuleResolver`
- Output `testonly_ = 1` in generated `import_external` rule

## Flow

```
wix.artifact(testonly=True) → JSON → Dependency(isTestOnly=true) → import_external(testonly_=1)
```

## Testing

- Added unit tests for `RuleResolver` and `DependencyConfigAugmenter`
- All existing tests pass